### PR TITLE
Support for emphasis extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ The XAML renderer outputs a string in a similar way as the HTML renderer. This s
 
 Supports all standard features from Markdig (i.e. fully CommonMark compliant).
 
-Additionally, the following extensions are supported (WPF renderer only):
+Additionally, the following extensions are supported:
 - **Auto-links**
-- **Task lists**
-- **Tables** (partial support of grid and pipe tables)
+- **Task lists** (WPF renderer only)
+- **Tables** (partial support of grid and pipe tables) (WPF renderer only)
+- **Extra emphasis**

--- a/src/Markdig.Wpf/MarkdownExtensions.cs
+++ b/src/Markdig.Wpf/MarkdownExtensions.cs
@@ -25,7 +25,8 @@ namespace Markdig.Wpf
                 .UseAutoLinks()
                 .UseGridTables()
                 .UsePipeTables()
-                .UseTaskLists();
+                .UseTaskLists()
+                .UseEmphasisExtras();
         }
     }
 }

--- a/src/Markdig.Wpf/MarkdownExtensions.cs
+++ b/src/Markdig.Wpf/MarkdownExtensions.cs
@@ -22,11 +22,11 @@ namespace Markdig.Wpf
         {
             if (pipeline == null) throw new ArgumentNullException(nameof(pipeline));
             return pipeline
-                .UseAutoLinks()
+                .UseEmphasisExtras()
                 .UseGridTables()
                 .UsePipeTables()
                 .UseTaskLists()
-                .UseEmphasisExtras();
+                .UseAutoLinks();
         }
     }
 }

--- a/src/Markdig.Wpf/Renderers/Wpf/Inlines/EmphasisInlineRenderer.cs
+++ b/src/Markdig.Wpf/Renderers/Wpf/Inlines/EmphasisInlineRenderer.cs
@@ -2,25 +2,46 @@
 // This file is licensed under the MIT license.
 // See the LICENSE.md file in the project root for more information.
 
+using System.Windows;
 using System.Windows.Documents;
 using Markdig.Annotations;
 using Markdig.Syntax.Inlines;
+using Markdig.Wpf;
 
 namespace Markdig.Renderers.Wpf.Inlines
 {
     /// <summary>
     /// A WPF renderer for an <see cref="EmphasisInline"/>.
     /// </summary>
-    /// <seealso cref="Markdig.Renderers.Wpf.WpfObjectRenderer{Markdig.Syntax.Inlines.EmphasisInline}" />
+    /// <seealso cref="EmphasisInline" />
     public class EmphasisInlineRenderer : WpfObjectRenderer<EmphasisInline>
     {
         protected override void Write([NotNull] WpfRenderer renderer, [NotNull] EmphasisInline obj)
         {
             Span span = null;
 
-            if (obj.DelimiterChar == '*' || obj.DelimiterChar == '_')
+            switch (obj.DelimiterChar)
             {
-                span = obj.IsDouble ? (Span)new Bold() : new Italic();
+                case '*':
+                case '_':
+                    span = obj.IsDouble ? (Span)new Bold() : new Italic();
+                    break;
+                case '~':
+                    span = new Span();
+                    span.SetResourceReference(FrameworkContentElement.StyleProperty, obj.IsDouble ? Styles.StrikeThroughStyleKey: Styles.SubscriptStyleKey);
+                    break;
+                case '^':
+                    span = new Span();
+                    span.SetResourceReference(FrameworkContentElement.StyleProperty, Styles.SuperscriptStyleKey);
+                    break;
+                case '+':
+                    span = new Span();
+                    span.SetResourceReference(FrameworkContentElement.StyleProperty, Styles.InsertedStyleKey);
+                    break;
+                case '=':
+                    span = new Span();
+                    span.SetResourceReference(FrameworkContentElement.StyleProperty, Styles.MarkedStyleKey);
+                    break;
             }
 
             if (span != null)

--- a/src/Markdig.Wpf/Renderers/Xaml/Inlines/EmphasisInlineRenderer.cs
+++ b/src/Markdig.Wpf/Renderers/Xaml/Inlines/EmphasisInlineRenderer.cs
@@ -36,7 +36,25 @@ namespace Markdig.Renderers.Xaml.Inlines
         protected override void Write([NotNull] XamlRenderer renderer, [NotNull] EmphasisInline obj)
         {
             var tag = GetTag(obj);
-            renderer.Write("<").Write(tag).Write(">");
+            renderer.Write("<").Write(tag);
+            switch (obj.DelimiterChar)
+            {
+                case '~':
+                    renderer.Write(obj.IsDouble
+                        ? " Style=\"{StaticResource {x:Static markdig:Styles.StrikeThroughStyleKey}}\""
+                        : " Style=\"{StaticResource {x:Static markdig:Styles.SubscriptStyleKey}}\"");
+                    break;
+                case '^':
+                    renderer.Write(" Style=\"{StaticResource {x:Static markdig:Styles.SuperscriptStyleKey}}\"");
+                    break;
+                case '+':
+                    renderer.Write(" Style=\"{StaticResource {x:Static markdig:Styles.InsertedStyleKey}}\"");
+                    break;
+                case '=':
+                    renderer.Write(" Style=\"{StaticResource {x:Static markdig:Styles.MarkedStyleKey}}\"");
+                    break;
+            }
+            renderer.Write(">");
             renderer.WriteChildren(obj);
             renderer.Write("</").Write(tag).Write(">");
         }
@@ -53,7 +71,7 @@ namespace Markdig.Renderers.Xaml.Inlines
             {
                 return obj.IsDouble ? "Bold" : "Italic";
             }
-            return null;
+            return "Span";
         }
     }
 }

--- a/src/Markdig.Wpf/Renderers/Xaml/Inlines/EmphasisInlineRenderer.cs
+++ b/src/Markdig.Wpf/Renderers/Xaml/Inlines/EmphasisInlineRenderer.cs
@@ -39,6 +39,9 @@ namespace Markdig.Renderers.Xaml.Inlines
             renderer.Write("<").Write(tag);
             switch (obj.DelimiterChar)
             {
+                case '*':
+                case '_':
+                    break;
                 case '~':
                     renderer.Write(obj.IsDouble
                         ? " Style=\"{StaticResource {x:Static markdig:Styles.StrikeThroughStyleKey}}\""

--- a/src/Markdig.Wpf/Styles.cs
+++ b/src/Markdig.Wpf/Styles.cs
@@ -59,9 +59,33 @@ namespace Markdig.Wpf
         public static ComponentResourceKey ImageStyleKey { get; } = new ComponentResourceKey(typeof(Styles), nameof(ImageStyleKey));
 
         /// <summary>
+        /// Resource Key for the InsertedStyle.
+        /// </summary>
+        public static ComponentResourceKey InsertedStyleKey { get; } = new ComponentResourceKey(typeof(Styles), nameof(InsertedStyleKey));
+
+        /// <summary>
+        /// Resource Key for the MarkedStyle.
+        /// </summary>
+        public static ComponentResourceKey MarkedStyleKey { get; } = new ComponentResourceKey(typeof(Styles), nameof(MarkedStyleKey));
+
+        /// <summary>
         /// Resource Key for the QuoteBlockStyle.
         /// </summary>
         public static ComponentResourceKey QuoteBlockStyleKey { get; } = new ComponentResourceKey(typeof(Styles), nameof(QuoteBlockStyleKey));
+
+        /// <summary>
+        /// Resource Key for the StrikeThroughStyle.
+        /// </summary>
+        public static ComponentResourceKey StrikeThroughStyleKey { get; } = new ComponentResourceKey(typeof(Styles), nameof(StrikeThroughStyleKey));
+        /// <summary>
+        /// Resource Key for the SubscriptStyle.
+        /// </summary>
+        public static ComponentResourceKey SubscriptStyleKey { get; } = new ComponentResourceKey(typeof(Styles), nameof(SubscriptStyleKey));
+
+        /// <summary>
+        /// Resource Key for the SuperscriptStyle.
+        /// </summary>
+        public static ComponentResourceKey SuperscriptStyleKey { get; } = new ComponentResourceKey(typeof(Styles), nameof(SuperscriptStyleKey));
 
         /// <summary>
         /// Resource Key for the TableStyle.
@@ -86,30 +110,5 @@ namespace Markdig.Wpf
         /// Resource Key for the ThematicBreakStyle.
         /// </summary>
         public static ComponentResourceKey ThematicBreakStyleKey { get; } = new ComponentResourceKey(typeof(Styles), nameof(ThematicBreakStyleKey));
-
-        /// <summary>
-        /// Resource Key for the SubscriptStyle.
-        /// </summary>
-        public static ComponentResourceKey SubscriptStyleKey { get; } = new ComponentResourceKey(typeof(Styles), nameof(SubscriptStyleKey));
-
-        /// <summary>
-        /// Resource Key for the SubscriptStyle.
-        /// </summary>
-        public static ComponentResourceKey SuperscriptStyleKey { get; } = new ComponentResourceKey(typeof(Styles), nameof(SuperscriptStyleKey));
-
-        /// <summary>
-        /// Resource Key for the StrikeThroughStyle.
-        /// </summary>
-        public static ComponentResourceKey StrikeThroughStyleKey { get; } = new ComponentResourceKey(typeof(Styles), nameof(StrikeThroughStyleKey));
-
-        /// <summary>
-        /// Resource Key for the InsertedStyleKeyStyle.
-        /// </summary>
-        public static ComponentResourceKey InsertedStyleKey { get; } = new ComponentResourceKey(typeof(Styles), nameof(InsertedStyleKey));
-
-        /// <summary>
-        /// Resource Key for the MarkedStyleKeyStyle.
-        /// </summary>
-        public static ComponentResourceKey MarkedStyleKey { get; } = new ComponentResourceKey(typeof(Styles), nameof(MarkedStyleKey));
     }
 }

--- a/src/Markdig.Wpf/Styles.cs
+++ b/src/Markdig.Wpf/Styles.cs
@@ -86,5 +86,30 @@ namespace Markdig.Wpf
         /// Resource Key for the ThematicBreakStyle.
         /// </summary>
         public static ComponentResourceKey ThematicBreakStyleKey { get; } = new ComponentResourceKey(typeof(Styles), nameof(ThematicBreakStyleKey));
+
+        /// <summary>
+        /// Resource Key for the SubscriptStyle.
+        /// </summary>
+        public static ComponentResourceKey SubscriptStyleKey { get; } = new ComponentResourceKey(typeof(Styles), nameof(SubscriptStyleKey));
+
+        /// <summary>
+        /// Resource Key for the SubscriptStyle.
+        /// </summary>
+        public static ComponentResourceKey SuperscriptStyleKey { get; } = new ComponentResourceKey(typeof(Styles), nameof(SuperscriptStyleKey));
+
+        /// <summary>
+        /// Resource Key for the StrikeThroughStyle.
+        /// </summary>
+        public static ComponentResourceKey StrikeThroughStyleKey { get; } = new ComponentResourceKey(typeof(Styles), nameof(StrikeThroughStyleKey));
+
+        /// <summary>
+        /// Resource Key for the InsertedStyleKeyStyle.
+        /// </summary>
+        public static ComponentResourceKey InsertedStyleKey { get; } = new ComponentResourceKey(typeof(Styles), nameof(InsertedStyleKey));
+
+        /// <summary>
+        /// Resource Key for the MarkedStyleKeyStyle.
+        /// </summary>
+        public static ComponentResourceKey MarkedStyleKey { get; } = new ComponentResourceKey(typeof(Styles), nameof(MarkedStyleKey));
     }
 }

--- a/src/Markdig.Wpf/Themes/generic.xaml
+++ b/src/Markdig.Wpf/Themes/generic.xaml
@@ -74,8 +74,23 @@
     <Setter Property="Stretch" Value="Fill" />
     <Setter Property="Stroke" Value="Black" />
   </Style>
-    
-  <!-- MarkdownViewer Template-->  
+  <Style TargetType="{x:Type Span}" x:Key="{x:Static markdig:Styles.SubscriptStyleKey}">
+    <Setter Property="Typography.Variants" Value="Subscript" />
+  </Style>
+  <Style TargetType="{x:Type Span}" x:Key="{x:Static markdig:Styles.SuperscriptStyleKey}">
+    <Setter Property="Typography.Variants" Value="Superscript" />
+  </Style>
+  <Style TargetType="{x:Type Span}" x:Key="{x:Static markdig:Styles.StrikeThroughStyleKey}">
+    <Setter Property="TextBlock.TextDecorations" Value="Strikethrough" />
+  </Style>
+  <Style TargetType="{x:Type Span}" x:Key="{x:Static markdig:Styles.InsertedStyleKey}">
+    <Setter Property="TextBlock.TextDecorations" Value="Underline" />
+  </Style>
+  <Style TargetType="{x:Type Span}" x:Key="{x:Static markdig:Styles.MarkedStyleKey}">
+    <Setter Property="Background" Value="Yellow" />
+  </Style>
+
+  <!-- MarkdownViewer Template-->
   <Style TargetType="markdig:MarkdownViewer">
     <Setter Property="Template">
       <Setter.Value>


### PR DESCRIPTION
This PR adds support for emphasis extensions (subscript, superscript, strike through, inserted, and marked)
 to both WPF and XAML rendering. All of them can be customized with styles.

This also fixes part of @amkuchta in #10.