### PR TITLE
[Markdig.Wpf] Fixed issues where renderer incorrectly adds white space

### DIFF
--- a/src/Markdig.Wpf/Renderers/Wpf/Inlines/LineBreakInlineRenderer.cs
+++ b/src/Markdig.Wpf/Renderers/Wpf/Inlines/LineBreakInlineRenderer.cs
@@ -21,6 +21,10 @@ namespace Markdig.Renderers.Wpf.Inlines
             {
                 renderer.WriteInline(new LineBreak());
             }
+            else {
+                // Soft line break.
+                renderer.WriteText(" ");
+            }
         }
     }
 }

--- a/src/Markdig.Wpf/Renderers/WpfRenderer.cs
+++ b/src/Markdig.Wpf/Renderers/WpfRenderer.cs
@@ -165,50 +165,7 @@ namespace Markdig.Renderers
 
         private static void AddInline([NotNull] IAddChild parent, [NotNull] Inline inline)
         {
-            if (!EndsWithSpace(parent) && !StartsWithSpace(inline))
-            {
-                parent.AddText(" ");
-            }
-
             parent.AddChild(inline);
-        }
-
-        private static bool StartsWithSpace([NotNull] Inline inline)
-        {
-            while (true)
-            {
-                if (inline is Run run)
-                {
-                    return run.Text.Length == 0 || run.Text.First().IsWhitespace();
-                }
-                if (inline is Span span)
-                {
-                    inline = span.Inlines.FirstInline;
-                    continue;
-                }
-
-                return true;
-            }
-        }
-
-        private static bool EndsWithSpace([NotNull] IAddChild element)
-        {
-            while (true)
-            {
-                var inlines = (element as Span)?.Inlines ?? (element as Paragraph)?.Inlines;
-
-                if (inlines?.LastInline is Run run)
-                {
-                    return run.Text.Length == 0 || run.Text.Last().IsWhitespace();
-                }
-                if (inlines?.LastInline is Span span)
-                {
-                    element = span;
-                    continue;
-                }
-
-                return true;
-            }
         }
     }
 }

--- a/src/Markdig.Wpf/Renderers/WpfRenderer.cs
+++ b/src/Markdig.Wpf/Renderers/WpfRenderer.cs
@@ -97,8 +97,10 @@ namespace Markdig.Renderers
                 var slices = lines.Lines;
                 for (var i = 0; i < lines.Count; i++)
                 {
+                    if (i != 0)
+                        WriteInline(new LineBreak());
+
                     WriteText(ref slices[i].Slice);
-                    WriteInline(new LineBreak());
                 }
             }
         }


### PR DESCRIPTION
This PR fixes a couple of issues where the renderer would incorrectly add white space:

- Spaces were always added between inlines (#12). Instead we should only add spaces when rendering [soft line breaks](https://spec.commonmark.org/0.28/#soft-line-breaks).
- Code blocks always had an extra new line at the end.