### PR TITLE
Hyperlink improvements

### DIFF
--- a/src/Markdig.Wpf/Renderers/Wpf/Inlines/AutoLinkInlineRenderer.cs
+++ b/src/Markdig.Wpf/Renderers/Wpf/Inlines/AutoLinkInlineRenderer.cs
@@ -3,6 +3,7 @@
 // See the LICENSE.md file in the project root for more information.
 
 using System;
+using System.Windows;
 using System.Windows.Documents;
 using Markdig.Annotations;
 using Markdig.Syntax.Inlines;
@@ -33,6 +34,8 @@ namespace Markdig.Renderers.Wpf.Inlines
                 NavigateUri = new Uri(url, UriKind.RelativeOrAbsolute),
                 ToolTip = url,
             };
+
+            hyperlink.SetResourceReference(FrameworkContentElement.StyleProperty, Styles.HyperlinkStyleKey);
 
             renderer.Push(hyperlink);
             renderer.WriteText(link.Url);

--- a/src/Markdig.Wpf/Renderers/Wpf/Inlines/AutoLinkInlineRenderer.cs
+++ b/src/Markdig.Wpf/Renderers/Wpf/Inlines/AutoLinkInlineRenderer.cs
@@ -21,6 +21,10 @@ namespace Markdig.Renderers.Wpf.Inlines
         protected override void Write([NotNull] WpfRenderer renderer, [NotNull] AutolinkInline link)
         {
             var url = link.Url;
+            if (link.IsEmail)
+            {
+                url = "mailto:" + url;
+            }
 
             if (!Uri.IsWellFormedUriString(url, UriKind.RelativeOrAbsolute))
             {
@@ -32,7 +36,7 @@ namespace Markdig.Renderers.Wpf.Inlines
                 Command = Commands.Hyperlink,
                 CommandParameter = url,
                 NavigateUri = new Uri(url, UriKind.RelativeOrAbsolute),
-                ToolTip = url,
+                ToolTip = link.Url,
             };
 
             hyperlink.SetResourceReference(FrameworkContentElement.StyleProperty, Styles.HyperlinkStyleKey);

--- a/src/Markdig.Wpf/Renderers/Wpf/Inlines/AutoLinkInlineRenderer.cs
+++ b/src/Markdig.Wpf/Renderers/Wpf/Inlines/AutoLinkInlineRenderer.cs
@@ -34,7 +34,9 @@ namespace Markdig.Renderers.Wpf.Inlines
                 ToolTip = url,
             };
 
-            renderer.WriteInline(hyperlink);
+            renderer.Push(hyperlink);
+            renderer.WriteText(link.Url);
+            renderer.Pop();
         }
     }
 }

--- a/src/Markdig.Wpf/Renderers/Wpf/Inlines/LinkInlineRenderer.cs
+++ b/src/Markdig.Wpf/Renderers/Wpf/Inlines/LinkInlineRenderer.cs
@@ -50,6 +50,8 @@ namespace Markdig.Renderers.Wpf.Inlines
                     ToolTip = link.Title != string.Empty ? link.Title : null,
                 };
 
+                hyperlink.SetResourceReference(FrameworkContentElement.StyleProperty, Styles.HyperlinkStyleKey);
+
                 renderer.Push(hyperlink);
                 renderer.WriteChildren(link);
                 renderer.Pop();

--- a/src/Markdig.Wpf/Renderers/Xaml/Inlines/AutolinkInlineRenderer.cs
+++ b/src/Markdig.Wpf/Renderers/Xaml/Inlines/AutolinkInlineRenderer.cs
@@ -16,6 +16,7 @@ namespace Markdig.Renderers.Xaml.Inlines
         protected override void Write([NotNull] XamlRenderer renderer, [NotNull] AutolinkInline obj)
         {
             renderer.Write("<Hyperlink");
+            renderer.Write(" Style=\"{StaticResource {x:Static markdig:Styles.HyperlinkStyleKey}}\"");
             renderer.Write(" Command=\"{x:Static markdig:Commands.Hyperlink}\"");
             renderer.Write(" CommandParameter=\"").WriteEscapeUrl(obj.Url).Write("\"");
             renderer.Write(">");

--- a/src/Markdig.Wpf/Renderers/Xaml/Inlines/AutolinkInlineRenderer.cs
+++ b/src/Markdig.Wpf/Renderers/Xaml/Inlines/AutolinkInlineRenderer.cs
@@ -15,10 +15,16 @@ namespace Markdig.Renderers.Xaml.Inlines
     {
         protected override void Write([NotNull] XamlRenderer renderer, [NotNull] AutolinkInline obj)
         {
+            var url = obj.Url;
+            if (obj.IsEmail)
+            {
+                url = "mailto:" + url;
+            }
+
             renderer.Write("<Hyperlink");
             renderer.Write(" Style=\"{StaticResource {x:Static markdig:Styles.HyperlinkStyleKey}}\"");
             renderer.Write(" Command=\"{x:Static markdig:Commands.Hyperlink}\"");
-            renderer.Write(" CommandParameter=\"").WriteEscapeUrl(obj.Url).Write("\"");
+            renderer.Write(" CommandParameter=\"").WriteEscapeUrl(url).Write("\"");
             renderer.Write(">");
             renderer.WriteEscapeUrl(obj.Url);
             renderer.WriteLine("</Hyperlink>");

--- a/src/Markdig.Wpf/Renderers/Xaml/Inlines/LinkInlineRenderer.cs
+++ b/src/Markdig.Wpf/Renderers/Xaml/Inlines/LinkInlineRenderer.cs
@@ -32,8 +32,8 @@ namespace Markdig.Renderers.Xaml.Inlines
             }
             else
             {
-                // TODO: add support for hyperlink styling (esp. command)
                 renderer.Write("<Hyperlink");
+                renderer.Write(" Style=\"{StaticResource {x:Static markdig:Styles.HyperlinkStyleKey}}\"");
                 renderer.Write(" Command=\"{x:Static markdig:Commands.Hyperlink}\"");
                 renderer.Write(" CommandParameter=\"").WriteEscapeUrl(url).Write("\"");
                 if (!string.IsNullOrEmpty(obj.Title))

--- a/src/Markdig.Wpf/Styles.cs
+++ b/src/Markdig.Wpf/Styles.cs
@@ -57,6 +57,11 @@ namespace Markdig.Wpf
         public static ComponentResourceKey Heading6StyleKey { get; } = new ComponentResourceKey(typeof(Styles), nameof(Heading6StyleKey));
 
         /// <summary>
+        /// Resource Key for the HyperlinkStyle.
+        /// </summary>
+        public static ComponentResourceKey HyperlinkStyleKey { get; } = new ComponentResourceKey(typeof(Styles), nameof(HyperlinkStyleKey));
+
+        /// <summary>
         /// Resource Key for the ImageStyle.
         /// </summary>
         public static ComponentResourceKey ImageStyleKey { get; } = new ComponentResourceKey(typeof(Styles), nameof(ImageStyleKey));

--- a/src/Markdig.Wpf/Themes/generic.xaml
+++ b/src/Markdig.Wpf/Themes/generic.xaml
@@ -45,6 +45,9 @@
   <Style TargetType="{x:Type Paragraph}" x:Key="{x:Static markdig:Styles.Heading6StyleKey}">
     <!-- no changes -->
   </Style>
+  <Style TargetType="{x:Type Hyperlink}" x:Key="{x:Static markdig:Styles.HyperlinkStyleKey}">
+    <!-- no changes -->
+  </Style>
   <Style TargetType="{x:Type Image}" x:Key="{x:Static markdig:Styles.ImageStyleKey}">
     <Setter Property="MaxHeight" Value="{Binding RelativeSource={RelativeSource Self}, Path=Source.(BitmapSource.PixelHeight)}" />
     <Setter Property="MaxWidth" Value="{Binding RelativeSource={RelativeSource Self}, Path=Source.(BitmapSource.PixelWidth)}" />


### PR DESCRIPTION
I've made some improvements to links and autolinks:

* Added a hyperlink style.
* Fixed the WPF autolink renderer - the autolinks weren't being displayed.
* For email autolinks, the URL of the hyperlink is now "mailto:" followed by the email address.