### PR TITLE
Add net40 support and switch to new csproj file for nuget generation

### DIFF
--- a/src/Markdig.Wpf/Markdig.Wpf.csproj
+++ b/src/Markdig.Wpf/Markdig.Wpf.csproj
@@ -1,109 +1,34 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{01E40FB5-B4E9-489D-98D5-4771DDC2D1D7}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Markdig.Wpf</RootNamespace>
-    <AssemblyName>Markdig.Wpf</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Debug\Markdig.Wpf.xml</DocumentationFile>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Release\Markdig.Wpf.xml</DocumentationFile>
+    <LanguageTargets>$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Bin\Microsoft.CSharp.targets</LanguageTargets>
+    <TargetFrameworks>net40;net45</TargetFrameworks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Description>A WPF library for lunet-io/markdig</Description>
+    <Company>Nicolas Musset</Company>
+    <Version>0.2.7</Version>
+    <License>MIT</License>
+    <ProjectUrl>https://github.com/Kryptos-FR/markdig-wpf</ProjectUrl>
+    <RequireLicenseAcceptance>false</RequireLicenseAcceptance>
+    <NeutralLanguage>en</NeutralLanguage>
+    <Copyright>Copyright © Nicolas Musset 2016-2018</Copyright>
+    <ReleaseNotes>https://github.com/Kryptos-FR/markdig.wpf/blob/master/RELEASENOTES.md</ReleaseNotes>
+    <Tags>Markdown CommonMark md xaml WPF</Tags>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Markdig, Version=0.15.5.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Markdig.0.15.5\lib\net40\Markdig.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="Markdig" Version="0.15.7" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
-    <Reference Include="System.Core" />
     <Reference Include="System.Xaml" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Annotations\CanBeNullAttribute.cs" />
-    <Compile Include="Annotations\NotNullAttribute.cs" />
-    <Compile Include="Commands.cs" />
-    <Compile Include="Markdown.cs" />
-    <Compile Include="MarkdownExtensions.cs" />
-    <Compile Include="MarkdownViewer.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Renderers\Wpf\Extensions\TableRenderer.cs" />
-    <Compile Include="Renderers\Wpf\Extensions\TaskListRenderer.cs" />
-    <Compile Include="Renderers\Wpf\Inlines\HtmlEntityInlineRenderer.cs" />
-    <Compile Include="Renderers\Wpf\Inlines\AutolinkInlineRenderer.cs" />
-    <Compile Include="Renderers\Wpf\ThematicBreakRenderer.cs" />
-    <Compile Include="Renderers\Wpf\CodeBlockRenderer.cs" />
-    <Compile Include="Renderers\WpfRenderer.cs" />
-    <Compile Include="Renderers\Wpf\ListRenderer.cs" />
-    <Compile Include="Renderers\Wpf\HeadingRenderer.cs" />
-    <Compile Include="Renderers\Wpf\Inlines\CodeInlineRenderer.cs" />
-    <Compile Include="Renderers\Wpf\Inlines\DelimiterInlineRenderer.cs" />
-    <Compile Include="Renderers\Wpf\Inlines\EmphasisInlineRenderer.cs" />
-    <Compile Include="Renderers\Wpf\Inlines\LineBreakInlineRenderer.cs" />
-    <Compile Include="Renderers\Wpf\Inlines\LinkInlineRenderer.cs" />
-    <Compile Include="Renderers\Wpf\Inlines\LiteralInlineRenderer.cs" />
-    <Compile Include="Renderers\Wpf\QuoteBlockRenderer.cs" />
-    <Compile Include="Renderers\Wpf\ParagraphRenderer.cs" />
-    <Compile Include="Renderers\Wpf\WpfObjectRenderer.cs" />
-    <Compile Include="Renderers\XamlRenderer.cs" />
-    <Compile Include="Renderers\Xaml\CodeBlockRenderer.cs" />
-    <Compile Include="Renderers\Xaml\HeadingRenderer.cs" />
-    <Compile Include="Renderers\Xaml\HtmlBlockRenderer.cs" />
-    <Compile Include="Renderers\Xaml\Inlines\AutolinkInlineRenderer.cs" />
-    <Compile Include="Renderers\Xaml\Inlines\CodeInlineRenderer.cs" />
-    <Compile Include="Renderers\Xaml\Inlines\DelimiterInlineRenderer.cs" />
-    <Compile Include="Renderers\Xaml\Inlines\EmphasisInlineRenderer.cs" />
-    <Compile Include="Renderers\Xaml\Inlines\HtmlEntityInlineRenderer.cs" />
-    <Compile Include="Renderers\Xaml\Inlines\HtmlInlineRenderer.cs" />
-    <Compile Include="Renderers\Xaml\Inlines\LineBreakInlineRenderer.cs" />
-    <Compile Include="Renderers\Xaml\Inlines\LinkInlineRenderer.cs" />
-    <Compile Include="Renderers\Xaml\Inlines\LiteralInlineRenderer.cs" />
-    <Compile Include="Renderers\Xaml\ListRenderer.cs" />
-    <Compile Include="Renderers\Xaml\ParagraphRenderer.cs" />
-    <Compile Include="Renderers\Xaml\QuoteBlockRenderer.cs" />
-    <Compile Include="Renderers\Xaml\ThematicBreakRenderer.cs" />
-    <Compile Include="Renderers\Xaml\XamlObjectRenderer.cs" />
-    <Compile Include="Styles.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <Page Include="Themes\generic.xaml">
+    <Page Include="Themes\generic.xaml" Generator="MSBuild:Compile">
       <SubType>Designer</SubType>
     </Page>
   </ItemGroup>
   <ItemGroup>
     <None Include="Markdig.Wpf.nuspec" />
-    <None Include="packages.config" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/src/Markdig.Wpf/Properties/AssemblyInfo.cs
+++ b/src/Markdig.Wpf/Properties/AssemblyInfo.cs
@@ -1,39 +1,3 @@
-// Copyright (c) 2016-2017 Nicolas Musset. All rights reserved.
-// This file is licensed under the MIT license. 
-// See the LICENSE.md file in the project root for more information.
-
-using System.Reflection;
-using System.Resources;
 using System.Windows;
 
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("Markdig.Wpf")]
-[assembly: AssemblyDescription("A WPF library for lunet-io/markdig")]
-#if DEBUG
-[assembly: AssemblyConfiguration("Debug")]
-#else
-[assembly: AssemblyConfiguration("Release")]
-#endif
-[assembly: AssemblyCompany("Nicolas Musset")]
-[assembly: AssemblyProduct("Markdig.Wpf")]
-[assembly: AssemblyCopyright("Copyright © Nicolas Musset 2016-2018")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-[assembly: NeutralResourcesLanguage("en")]
-
-[assembly: AssemblyVersion(Markdig.Wpf.Markdown.Version)]
-[assembly: AssemblyFileVersion(Markdig.Wpf.Markdown.Version)]
 [assembly: ThemeInfo(ResourceDictionaryLocation.SourceAssembly, ResourceDictionaryLocation.SourceAssembly)]
-
-namespace Markdig.Wpf
-{
-    public static partial class Markdown
-    {
-        /// <summary>
-        /// Version of this library.
-        /// </summary>
-        public const string Version = "0.2.6";
-    }
-}

--- a/src/Markdig.Wpf/Renderers/WpfRenderer.cs
+++ b/src/Markdig.Wpf/Renderers/WpfRenderer.cs
@@ -73,7 +73,10 @@ namespace Markdig.Renderers
         /// </summary>
         /// <param name="leafBlock">The leaf block.</param>
         /// <returns>This instance</returns>
+#if !NET40
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+
         public void WriteLeafInline([NotNull] LeafBlock leafBlock)
         {
             if (leafBlock == null) throw new ArgumentNullException(nameof(leafBlock));
@@ -127,7 +130,10 @@ namespace Markdig.Renderers
             AddInline(stack.Peek(), inline);
         }
 
+#if !NET40
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+
         public void WriteText(ref StringSlice slice)
         {
             if (slice.Start > slice.End)
@@ -136,7 +142,10 @@ namespace Markdig.Renderers
             WriteText(slice.Text, slice.Start, slice.Length);
         }
 
+#if !NET40
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+
         public void WriteText([CanBeNull] string text)
         {
             WriteInline(new Run(text));

--- a/src/Markdig.Wpf/Renderers/XamlRenderer.cs
+++ b/src/Markdig.Wpf/Renderers/XamlRenderer.cs
@@ -7,13 +7,16 @@
 
 using System;
 using System.IO;
-using System.Runtime.CompilerServices;
 using System.Text;
 using Markdig.Annotations;
 using Markdig.Helpers;
 using Markdig.Renderers.Xaml;
 using Markdig.Renderers.Xaml.Inlines;
 using Markdig.Syntax;
+
+#if !NET40
+using System.Runtime.CompilerServices;
+#endif
 
 namespace Markdig.Renderers
 {
@@ -83,7 +86,9 @@ namespace Markdig.Renderers
         /// <param name="content">The content.</param>
         /// <returns>This instance</returns>
         [NotNull]
+#if !NET40
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public XamlRenderer WriteEscape([CanBeNull] string content)
         {
             if (string.IsNullOrEmpty(content))
@@ -100,7 +105,9 @@ namespace Markdig.Renderers
         /// <param name="softEscape">Only escape &lt; and &amp;</param>
         /// <returns>This instance</returns>
         [NotNull]
+#if !NET40
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public XamlRenderer WriteEscape(ref StringSlice slice, bool softEscape = false)
         {
             if (slice.Start > slice.End)
@@ -117,7 +124,9 @@ namespace Markdig.Renderers
         /// <param name="softEscape">Only escape &lt; and &amp;</param>
         /// <returns>This instance</returns>
         [NotNull]
+#if !NET40
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public XamlRenderer WriteEscape(StringSlice slice, bool softEscape = false)
         {
             return WriteEscape(ref slice, softEscape);
@@ -137,8 +146,8 @@ namespace Markdig.Renderers
             if (string.IsNullOrEmpty(content) || length == 0)
                 return this;
 
-            var end = offset + length;
-            var previousOffset = offset;
+            int end = offset + length;
+            int previousOffset = offset;
             for (; offset < end; offset++)
             {
                 switch (content[offset])
@@ -202,16 +211,16 @@ namespace Markdig.Renderers
             if (content == null)
                 return this;
 
-            var previousPosition = 0;
-            var length = content.Length;
+            int previousPosition = 0;
+            int length = content.Length;
 
-            for (var i = 0; i < length; i++)
+            for (int i = 0; i < length; i++)
             {
-                var c = content[i];
+                char c = content[i];
 
                 if (c < 128)
                 {
-                    var escape = HtmlHelper.EscapeUrlCharacter(c);
+                    string escape = HtmlHelper.EscapeUrlCharacter(c);
                     if (escape != null)
                     {
                         Write(content, previousPosition, i - previousPosition);
@@ -237,7 +246,7 @@ namespace Markdig.Renderers
                         bytes = Encoding.UTF8.GetBytes(new[] { c });
                     }
 
-                    foreach (var t in bytes)
+                    foreach (byte t in bytes)
                     {
                         Write($"%{t:X2}");
                     }
@@ -264,7 +273,7 @@ namespace Markdig.Renderers
             {
                 var lines = leafBlock.Lines;
                 var slices = lines.Lines;
-                for (var i = 0; i < lines.Count; i++)
+                for (int i = 0; i < lines.Count; i++)
                 {
                     if (!writeEndOfLines && i > 0)
                     {

--- a/src/Markdig.Wpf/packages.config
+++ b/src/Markdig.Wpf/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Markdig" version="0.15.5" targetFramework="net452" />
+  <package id="Markdig" version="0.15.7" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Modified the source to handle net40 scenario, because markdig itself supports this. The project uses the new csproj format which generates the nuspec and generates the nuget package easily.
Two outputs : net40 and net45, with inline optimizations disabled for net40 (because it doesn't support it).