### PR TITLE
Fixing readme path

### DIFF
--- a/src/Markdig.Wpf.SampleAppCustomized/MainWindow.xaml.cs
+++ b/src/Markdig.Wpf.SampleAppCustomized/MainWindow.xaml.cs
@@ -19,7 +19,7 @@ namespace Markdig.Wpf.SampleAppCustomized
 
         private void OnLoaded(object sender, RoutedEventArgs e)
         {
-            var path = "../../../../Documents/Markdig-readme.md";
+            var path = "Documents/Markdig-readme.md";
             Viewer.UCRootPath = path;
             Viewer.Markdown = File.ReadAllText(path);
         }


### PR DESCRIPTION
Fixing path for Markdig-readme.md on Markdig.Wpf.SampleAppCustomized that was causing System.IO.DirectoryNotFoundException throw