### PR TITLE
Add support for in-document linking (e.g. #my-id).

### DIFF
--- a/Documents/Markdig-readme.md
+++ b/Documents/Markdig-readme.md
@@ -1,4 +1,11 @@
-﻿# Markdig [![Build status](https://ci.appveyor.com/api/projects/status/hk391x8jcskxt1u8?svg=true)](https://ci.appveyor.com/project/xoofx/markdig) [![NuGet](https://img.shields.io/nuget/v/Markdig.svg)](https://www.nuget.org/packages/Markdig/) [![Donate](https://www.paypalobjects.com/en_US/i/btn/btn_donate_SM.gif)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=FRGHXBTP442JL)
+﻿* [Markdig](#markdig)
+  * [Features](#features)
+  * [Documentation](#documentation)
+  * [Download](#download)
+  * [Usage](#usage)
+
+
+# Markdig [![Build status](https://ci.appveyor.com/api/projects/status/hk391x8jcskxt1u8?svg=true)](https://ci.appveyor.com/project/xoofx/markdig) [![NuGet](https://img.shields.io/nuget/v/Markdig.svg)](https://www.nuget.org/packages/Markdig/) [![Donate](https://www.paypalobjects.com/en_US/i/btn/btn_donate_SM.gif)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=FRGHXBTP442JL)
 
 | Tables        | Are           | Cool  |
 | ------------- |:-------------:| -----:|

--- a/src/Markdig.Wpf/Commands.cs
+++ b/src/Markdig.Wpf/Commands.cs
@@ -20,5 +20,10 @@ namespace Markdig.Wpf
         /// Routed command for Images.
         /// </summary>
         public static RoutedCommand Image { get; } = new RoutedCommand(nameof(Image), typeof(Commands));
+
+        /// <summary>
+        /// Routed command for navigating to a heading in a document. Command parameter contains the heading id
+        /// </summary>
+        public static RoutedCommand Navigate { get; } = new RoutedCommand(nameof(Navigate), typeof(Commands));
     }
 }

--- a/src/Markdig.Wpf/MarkdownExtensions.cs
+++ b/src/Markdig.Wpf/MarkdownExtensions.cs
@@ -25,7 +25,8 @@ namespace Markdig.Wpf
                 .UseGridTables()
                 .UsePipeTables()
                 .UseTaskLists()
-                .UseAutoLinks();
+                .UseAutoLinks()
+                .UseAutoIdentifiers();
         }
     }
 }

--- a/src/Markdig.Wpf/Renderers/Wpf/HeadingRenderer.cs
+++ b/src/Markdig.Wpf/Renderers/Wpf/HeadingRenderer.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Windows;
 using System.Windows.Documents;
-
+using Markdig.Renderers.Html;
 using Markdig.Syntax;
 using Markdig.Wpf;
 
@@ -34,6 +34,12 @@ namespace Markdig.Renderers.Wpf
             if (styleKey != null)
             {
                 paragraph.SetResourceReference(FrameworkContentElement.StyleProperty, styleKey);
+            }
+
+            var attributes = obj.TryGetAttributes();
+            if (!String.IsNullOrEmpty(attributes?.Id))
+            {
+                MarkdownViewer.SetAnchorName(paragraph, attributes.Id);
             }
 
             renderer.Push(paragraph);

--- a/src/Markdig.Wpf/Renderers/Wpf/Inlines/LinkInlineRenderer.cs
+++ b/src/Markdig.Wpf/Renderers/Wpf/Inlines/LinkInlineRenderer.cs
@@ -27,7 +27,7 @@ namespace Markdig.Renderers.Wpf.Inlines
 
             var url = link.GetDynamicUrl != null ? link.GetDynamicUrl() ?? link.Url : link.Url;
 
-            if (!Uri.IsWellFormedUriString(url, UriKind.RelativeOrAbsolute))
+            if (!Uri.TryCreate(url, UriKind.RelativeOrAbsolute, out _))
             {
                 url = "#";
             }
@@ -53,12 +53,11 @@ namespace Markdig.Renderers.Wpf.Inlines
             {
                 var hyperlink = new Hyperlink
                 {
-                    Command = Commands.Hyperlink,
+                    Command = url.StartsWith("#") ? Commands.Navigate : Commands.Hyperlink,
                     CommandParameter = url,
                     NavigateUri = new Uri(url, UriKind.RelativeOrAbsolute),
                     ToolTip = !string.IsNullOrEmpty(link.Title) ? link.Title : null,
                 };
-
                 hyperlink.SetResourceReference(FrameworkContentElement.StyleProperty, Styles.HyperlinkStyleKey);
 
                 renderer.Push(hyperlink);

--- a/src/Markdig.Wpf/Themes/generic.xaml
+++ b/src/Markdig.Wpf/Themes/generic.xaml
@@ -99,6 +99,7 @@
       <Setter.Value>
         <ControlTemplate TargetType="markdig:MarkdownViewer">
           <FlowDocumentScrollViewer Document="{TemplateBinding Document}"
+                                    x:Name="PART_DocViewer"
                                     ScrollViewer.VerticalScrollBarVisibility="Auto"/>
         </ControlTemplate>
       </Setter.Value>


### PR DESCRIPTION
Add support for navigating to headers inside a document.

* Enables the `AutoIdentifiers` markdig extension to give each header a unique anchor name. This anchor name is exposed on the header blocks as an attached dependency property. 
* The LinkInlineRenderer calls `Uri.TryCreate` to determine if the URL is valid or not (fixes issue with links being replaced with `#` as described in #49 
  * If the link is to a header inside the same document, the command used is `Navigate` instead of `Link`
* The MarkdownViewer adds a command handler to the `Navigate` command which it sets to handled if the header was successfully navigated to. Otherwise the command will bubble up to whoever else is listening.
* Updated sample md file with a TOC to test this functionality

This is my first shot at this. I'm open to suggestion if you want it done in a different way. 