### PR TITLE
net45 removal

### DIFF
--- a/src/Markdig.Wpf.SampleApp/Markdig.Wpf.SampleApp.csproj
+++ b/src/Markdig.Wpf.SampleApp/Markdig.Wpf.SampleApp.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Markdig" Version="0.22.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Markdig.Wpf.SampleApp/Markdig.Wpf.SampleApp.csproj
+++ b/src/Markdig.Wpf.SampleApp/Markdig.Wpf.SampleApp.csproj
@@ -7,7 +7,7 @@
     <AssemblyTitle>Markdig.Wpf.SampleApp</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
     <VersionPrefix>0.5.0.1</VersionPrefix>
-    <TargetFrameworks>net452;netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0-windows</TargetFrameworks>
     <ApplicationIcon />
     <OutputType>WinExe</OutputType>
     <StartupObject />

--- a/src/Markdig.Wpf.SampleAppCustomized/Markdig.Wpf.SampleAppCustomized.csproj
+++ b/src/Markdig.Wpf.SampleAppCustomized/Markdig.Wpf.SampleAppCustomized.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Markdig" Version="0.22.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Markdig.Wpf.SampleAppCustomized/Markdig.Wpf.SampleAppCustomized.csproj
+++ b/src/Markdig.Wpf.SampleAppCustomized/Markdig.Wpf.SampleAppCustomized.csproj
@@ -7,7 +7,7 @@
     <AssemblyTitle>Markdig.Wpf.SampleAppCustomized</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
     <VersionPrefix>0.5.0.1</VersionPrefix>
-    <TargetFrameworks>net452;netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0-windows</TargetFrameworks>
     <ApplicationIcon />
     <OutputType>WinExe</OutputType>
     <StartupObject />

--- a/src/Markdig.Wpf/Markdig.Wpf.csproj
+++ b/src/Markdig.Wpf/Markdig.Wpf.csproj
@@ -7,7 +7,7 @@
     <AssemblyTitle>Markdig.Wpf</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
     <VersionPrefix>0.5.0.1</VersionPrefix>
-    <TargetFrameworks>net452;netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0-windows</TargetFrameworks>
     <SignAssembly Condition="'$(Configuration)' == 'Release_Signed'">true</SignAssembly>
     <PackageId>Markdig.Wpf</PackageId>
     <PackageId Condition="'$(SignAssembly)' == 'true'">Markdig.Wpf.Signed</PackageId>

--- a/src/Markdig.Wpf/Markdig.Wpf.csproj
+++ b/src/Markdig.Wpf/Markdig.Wpf.csproj
@@ -40,11 +40,11 @@
     <PackageReference Include="Markdig" Version="0.22.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Markdig.Xaml.ConsoleApp/Markdig.Xaml.ConsoleApp.csproj
+++ b/src/Markdig.Xaml.ConsoleApp/Markdig.Xaml.ConsoleApp.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Markdig" Version="0.22.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Markdig.Xaml.ConsoleApp/Markdig.Xaml.ConsoleApp.csproj
+++ b/src/Markdig.Xaml.ConsoleApp/Markdig.Xaml.ConsoleApp.csproj
@@ -7,7 +7,7 @@
     <AssemblyTitle>Markdig.Xaml.ConsoleApp</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
     <VersionPrefix>0.5.0.1</VersionPrefix>
-    <TargetFrameworks>net452;netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0-windows</TargetFrameworks>
     <ApplicationIcon />
     <OutputType>Exe</OutputType>
     <StartupObject />

--- a/src/Markdig.Xaml.SampleApp/Markdig.Xaml.SampleApp.csproj
+++ b/src/Markdig.Xaml.SampleApp/Markdig.Xaml.SampleApp.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Markdig" Version="0.22.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Markdig.Xaml.SampleApp/Markdig.Xaml.SampleApp.csproj
+++ b/src/Markdig.Xaml.SampleApp/Markdig.Xaml.SampleApp.csproj
@@ -7,7 +7,7 @@
     <AssemblyTitle>Markdig.Xaml.SampleApp</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
     <VersionPrefix>0.5.0.1</VersionPrefix>
-    <TargetFrameworks>net452;netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0-windows</TargetFrameworks>
     <ApplicationIcon />
     <OutputType>WinExe</OutputType>
     <StartupObject />


### PR DESCRIPTION
Remove support for out-of-support (i.e. obsolete) runtimes:
- .NET Framework 4.5.2 reached end-of-life on January 10th 2023
  - upgrade to .NET Framework 4.6.2
- .NET Core 3.1 reached end-of-life on December 13, 2022
  - upgrade to .NET 6 (LTS)

References:
- [.NET and .NET Core Support Policy](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core)
- [Microsoft .NET Framework ](https://learn.microsoft.com/fr-fr/lifecycle/products/microsoft-net-framework)

----
Relates to xoofx/markdig#690