### PR TITLE
Expanded the SampleAppCustomized project

### DIFF
--- a/src/Markdig.Wpf.SampleAppCustomized/Customized/ColumnScalingTableRenderer.cs
+++ b/src/Markdig.Wpf.SampleAppCustomized/Customized/ColumnScalingTableRenderer.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Linq;
+using System.Windows;
+using Markdig.Renderers.Wpf;
+using TableColumnAlign = Markdig.Extensions.Tables.TableColumnAlign;
+using Table = Markdig.Extensions.Tables.Table;
+using TableCell = Markdig.Extensions.Tables.TableCell;
+using TableRow = Markdig.Extensions.Tables.TableRow;
+using WpfDocs = System.Windows.Documents;
+
+
+namespace Markdig.Wpf.SampleAppCustomized.Customized
+{
+    public class ColumnScalingTableRenderer : WpfObjectRenderer<Table>
+    {
+        protected override void Write(Renderers.WpfRenderer renderer, Table table)
+        {
+            if (renderer == null) throw new ArgumentNullException(nameof(renderer));
+            if (table == null) throw new ArgumentNullException(nameof(table));
+
+            var wpfTable = new WpfDocs.Table();
+
+            wpfTable.SetResourceReference(FrameworkContentElement.StyleProperty, Styles.TableStyleKey);
+
+            #region Customization
+
+            var columnValueList = new System.Collections.Generic.List<string>?[table.ColumnDefinitions.Count];
+
+            #endregion
+            
+            foreach (var tableColumnDefinition in table.ColumnDefinitions)
+            {
+                wpfTable.Columns.Add(new WpfDocs.TableColumn
+                {
+                    Width = (tableColumnDefinition?.Width ?? 0) != 0 ?
+                        new GridLength(tableColumnDefinition!.Width, GridUnitType.Star) :
+                        GridLength.Auto,
+                });
+            }
+
+            var wpfRowGroup = new WpfDocs.TableRowGroup();
+
+            renderer.Push(wpfTable);
+            renderer.Push(wpfRowGroup);
+
+            foreach (var rowObj in table)
+            {
+                var row = (TableRow)rowObj;
+                var wpfRow = new WpfDocs.TableRow();
+
+                renderer.Push(wpfRow);
+
+                if (row.IsHeader)
+                {
+                    wpfRow.SetResourceReference(FrameworkContentElement.StyleProperty, Styles.TableHeaderStyleKey);
+                }
+
+                for (var i = 0; i < row.Count; i++)
+                {
+                    #region Customization
+
+                    if (i < columnValueList.Length - 1 && columnValueList[i] is null)
+                        columnValueList[i] = new(row.Count);
+
+                    #endregion
+                    
+                    var cellObj = row[i];
+                    var cell = (TableCell)cellObj;
+                    var wpfCell = new WpfDocs.TableCell
+                    {
+                        ColumnSpan = cell.ColumnSpan,
+                        RowSpan = cell.RowSpan,
+                    };
+                    
+                    wpfCell.SetResourceReference(FrameworkContentElement.StyleProperty, Styles.TableCellStyleKey);
+                    
+                    renderer.Push(wpfCell);
+                    renderer.Write(cell);
+                    renderer.Pop();
+
+                    var txt = new WpfDocs.TextRange(wpfCell.ContentStart, wpfCell.ContentEnd).Text;
+                    columnValueList[i]?.Add(txt);
+                    
+                    if (table.ColumnDefinitions.Count > 0)
+                    {
+                        var columnIndex = cell.ColumnIndex < 0 || cell.ColumnIndex >= table.ColumnDefinitions.Count
+                            ? i
+                            : cell.ColumnIndex;
+                        columnIndex = columnIndex >= table.ColumnDefinitions.Count ? table.ColumnDefinitions.Count - 1 : columnIndex;
+                        var alignment = table.ColumnDefinitions[columnIndex].Alignment;
+
+
+                        #region Customization
+                        
+                        if (row.IsHeader)
+                            alignment = TableColumnAlign.Center;
+
+                        #endregion
+                        
+                        if (alignment.HasValue)
+                        {
+                            switch (alignment)
+                            {
+                                case TableColumnAlign.Center:
+                                    wpfCell.TextAlignment = TextAlignment.Center;
+                                    break;
+                                case TableColumnAlign.Right:
+                                    wpfCell.TextAlignment = TextAlignment.Right;
+                                    break;
+                                case TableColumnAlign.Left:
+                                    wpfCell.TextAlignment = TextAlignment.Left;
+                                    break;
+                            }
+                        }
+                    }
+                }
+
+                renderer.Pop();
+            }
+
+            #region Customization
+
+            var weights = columnValueList.Select(x => x?.Max(y => y.Length) ?? 0.0).ToArray();
+            var sum = weights.Sum();
+            for (int i = 0; i < weights.Length; i++)
+            {
+                var col = wpfTable.Columns[i];
+                var weight = weights[i];
+                col.Width = weight == 0
+                          ? new GridLength(0, GridUnitType.Pixel)
+                          : new GridLength(weight / sum * 100.0, GridUnitType.Star);
+            }
+
+            #endregion
+            
+            renderer.Pop();
+            renderer.Pop();
+        }
+
+        
+    }
+}

--- a/src/Markdig.Wpf.SampleAppCustomized/Customized/WpfRenderer.cs
+++ b/src/Markdig.Wpf.SampleAppCustomized/Customized/WpfRenderer.cs
@@ -1,24 +1,33 @@
 ﻿namespace Markdig.Wpf.SampleAppCustomized.Customized
 {
+    /// <summary>
+    /// Create a custom Renderer instead of using the one in the Markdig.Wpf package 
+    /// </summary>
     public class WpfRenderer : Markdig.Renderers.WpfRenderer
     {
-        private string _linkpath;
+        private readonly Renderers.IMarkdownObjectRenderer[] _injections;
 
         /// <summary>
         /// Initializes the WPF renderer
         /// </summary>
-        /// <param name="linkpath">image path for the custom LinkInlineRenderer</param>
-        public WpfRenderer(string linkpath) : base()
+        /// <param name="injectRenderers">custom renderer injection list</param>
+        public WpfRenderer(params Renderers.IMarkdownObjectRenderer[] injectRenderers) : base()
         {
-            _linkpath = linkpath;
+            _injections = injectRenderers;
         }
 
         /// <summary>
-        /// Load first the custom renderer's
+        /// Load our custom renderer's before the base versions. By doing this, our renderers can
+        /// handle/continue on that specific Markdig type before ever reaching the default renderer
         /// </summary>
         protected override void LoadRenderers()
         {
-            ObjectRenderers.Add(new LinkInlineRenderer(_linkpath));
+            if (_injections.Length > 0)
+            {
+                foreach (var renderer in _injections)
+                    ObjectRenderers.Add(renderer); 
+            }
+
             base.LoadRenderers();
         }
     }

--- a/src/Markdig.Wpf.SampleAppCustomized/MainWindow.xaml
+++ b/src/Markdig.Wpf.SampleAppCustomized/MainWindow.xaml
@@ -6,15 +6,107 @@
         xmlns:local="clr-namespace:Markdig.Wpf.SampleAppCustomized.Customized"
         xmlns:markdig="clr-namespace:Markdig.Wpf;assembly=Markdig.Wpf"
         mc:Ignorable="d"
+        DataContext="{Binding RelativeSource={RelativeSource Self}}"
         Title="MainWindow">
+    <Window.Resources>
+        <!-- Define some new styles based on the predefined style keys -->
+        <Style TargetType="Paragraph" x:Key="MyH1" BasedOn="{StaticResource {x:Static markdig:Styles.Heading1StyleKey}}">
+            <Setter Property="Foreground" Value="Red"/>
+            <Setter Property="FontWeight" Value="ExtraBold"/>
+            <Setter Property="FontSize" Value="30"/>
+        </Style>
+        <Style TargetType="Paragraph" x:Key="MyH2" BasedOn="{StaticResource {x:Static markdig:Styles.Heading2StyleKey}}">
+            <Setter Property="Foreground" Value="LimeGreen"/>
+            <Setter Property="FontStyle" Value="Italic"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="FontSize" Value="26"/>
+        </Style>
+        <Style TargetType="Paragraph" x:Key="MyH3" BasedOn="{StaticResource {x:Static markdig:Styles.Heading3StyleKey}}">
+            <Setter Property="Foreground" Value="Blue"/>
+            <Setter Property="FontFamily" Value="Consolas"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="FontSize" Value="20"/>
+            <Setter Property="TextDecorations" Value="Underline"/>
+        </Style>
+        <Style TargetType="TableRow" x:Key="MyTableHeader" BasedOn="{StaticResource {x:Static markdig:Styles.TableHeaderStyleKey}}">
+            <Setter Property="Background" Value="Gray"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="FontSize" Value="18"/>
+        </Style>
+        <Style TargetType="TableCell" x:Key="MyTableCell" BasedOn="{StaticResource {x:Static markdig:Styles.TableCellStyleKey}}">
+            <Setter Property="Padding" Value="8,4"/>
+        </Style>
+        
+    </Window.Resources>
+    
     <FrameworkElement.CommandBindings>
         <CommandBinding Command="{x:Static markdig:Commands.Hyperlink}" Executed="OpenHyperlink" />
         <CommandBinding Command="{x:Static markdig:Commands.Image}" Executed="ClickOnImage" />
     </FrameworkElement.CommandBindings>
+    
     <DockPanel>
-        <Button x:Name="ToggleExtensionsButton" DockPanel.Dock="Top" HorizontalAlignment="Center"
-            Content="Toggle supported extensions" Click="ToggleExtensionsButton_OnClick" />
-        
-        <local:MarkdownViewer x:Name="Viewer"/>
+        <ToggleButton x:Name="ToggleExtensionsButton" 
+                      DockPanel.Dock="Top" HorizontalAlignment="Center" Padding="5,1"
+                      IsThreeState="True" IsChecked="{Binding PresentationState}">
+            <ToggleButton.Style>
+                <Style TargetType="{x:Type ToggleButton}">
+                    <Style.Triggers>
+                        <Trigger Property="IsChecked" Value="True">
+                            <Setter Property="Content" Value="Current State: all Pipeline extensions, custom Renderers &amp; Styles"/>
+                        </Trigger>
+                        <Trigger Property="IsChecked" Value="{x:Null}">
+                            <Setter Property="Content" Value="Current State: no customization, no Pipeline extensions or Styles"/>
+                        </Trigger>
+                        <Trigger Property="IsChecked" Value="False">
+                            <Setter Property="Content" Value="Current State: no customization, just all supported Pipeline extensions"/>
+                        </Trigger>
+                    </Style.Triggers>
+                </Style>
+            </ToggleButton.Style>
+        </ToggleButton>
+            
+        <local:MarkdownViewer x:Name="Viewer">
+            <local:MarkdownViewer.Style>
+                <!-- Brought over the control style/template & hooked up custom style injection to toggle button -->
+                <Style TargetType="markdig:MarkdownViewer">
+                    <Setter Property="Template">
+                        <Setter.Value>
+                            <!-- Default MarkdownViewer template -->
+                            <ControlTemplate TargetType="markdig:MarkdownViewer">
+                                <FlowDocumentScrollViewer Document="{TemplateBinding Document}"
+                                                          ScrollViewer.VerticalScrollBarVisibility="Auto"/>
+                            </ControlTemplate>
+                        </Setter.Value>
+                    </Setter>
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding IsChecked, ElementName=ToggleExtensionsButton}" Value="True">
+                            <Setter Property="Template">
+                                <Setter.Value>
+                                    <!-- Custom MarkdownViewer template that injects style key overrides -->
+                                    <ControlTemplate TargetType="markdig:MarkdownViewer">
+                                        <ControlTemplate.Resources>
+                                            <!-- Override some of the predefined style keys using our custom styles -->
+                                            <Style TargetType="Paragraph" x:Key="{x:Static markdig:Styles.Heading1StyleKey}" 
+                                                   BasedOn="{StaticResource MyH1}" />
+                                            <Style TargetType="Paragraph" x:Key="{x:Static markdig:Styles.Heading2StyleKey}" 
+                                                   BasedOn="{StaticResource MyH2}"/>
+                                            <Style TargetType="Paragraph" x:Key="{x:Static markdig:Styles.Heading3StyleKey}" 
+                                                   BasedOn="{StaticResource MyH3}" />
+                                            <Style TargetType="TableRow" x:Key="{x:Static markdig:Styles.TableHeaderStyleKey}" 
+                                                   BasedOn="{StaticResource MyTableHeader}" />
+                                            <Style TargetType="TableCell" x:Key="{x:Static markdig:Styles.TableCellStyleKey}" 
+                                                   BasedOn="{StaticResource MyTableCell}" />
+                                        </ControlTemplate.Resources>
+                                        <FlowDocumentScrollViewer Document="{TemplateBinding Document}"
+                                                                  ScrollViewer.VerticalScrollBarVisibility="Auto"/>
+                                    </ControlTemplate>
+                                </Setter.Value>
+                            </Setter>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </local:MarkdownViewer.Style>
+        </local:MarkdownViewer>
     </DockPanel>
 </Window>


### PR DESCRIPTION
Since there really isn't any documentation and I wound up digging into this enough to mostly understand the customization. I figured I would update the **SampleAppCustomized** project to show more of what can be done.

### MainWindow.xaml/.cs
- Added style customization and showed a method of injecting them while re-styling the MarkdownViewer.
- Changed the Button to a ToggleButton so it now has: All Supported, Default & Customized states.

### Customized.ColumnScalingTableRenderer.cs
- Largely a copy of the TableRenderer, but I did use `#regions Customization` to help show the diffs.
- This specific implementation forces header rows to center & does a distribution scale on the column widths.

### Customized.WpfRenderer.cs
- I changed the concept of this around. Instead of it constructing custom renderers, it just "uses" the ones it is given.

### Customized.MarkdownViewer.cs
- Basically does the same work but in a different order and accounts for the addition presentation state.
- I don't believe that forced update to `UCRootPath` is still required, but I moved/left it there since I am unfamiliar with the problem it was addressing.